### PR TITLE
Adding key type information (*, 0/1 and 1) on keys

### DIFF
--- a/src/components/model.pcss
+++ b/src/components/model.pcss
@@ -55,6 +55,7 @@
   }
 
   .association-to-right {
+    font-family: monospace;
     position: absolute;
     right: -1em;
     top: 2.5em;
@@ -113,6 +114,7 @@
 
   .association-to-left {
     box-sizing: border-box;
+    font-family: monospace;
     left: -1em;
     position: absolute;
     top: 2.5em;

--- a/src/logic/logic.js
+++ b/src/logic/logic.js
@@ -35,7 +35,7 @@ function assocSymbol(field) {
     case 'PRIMARY_KEY':
       return '0/1';
     default:
-      return '0..n';
+      return '*';
   }
 }
 

--- a/src/logic/logic.js
+++ b/src/logic/logic.js
@@ -33,9 +33,9 @@ function assocSymbol(field) {
     case 'PERFECT_KEY':
       return '1';
     case 'PRIMARY_KEY':
-      return '1';
+      return '0/1';
     default:
-      return 'n';
+      return '0..n';
   }
 }
 
@@ -56,7 +56,7 @@ function toSubsetRatioText(qSubsetratio) {
 
 function toSubsetRatioTitle(field) {
   if (!!field.qnPresentDistinctValues && !!field.qnTotalDistinctValues && field.qnPresentDistinctValues < field.qnTotalDistinctValues) {
-    return `Only ${field.qnPresentDistinctValues} out of ${field.qnTotalDistinctValues} values are present in this table.`;
+    return `${field.qnPresentDistinctValues} out of ${field.qnTotalDistinctValues} values are present in this table.`;
   }
   return '';
 }


### PR DESCRIPTION
Adding more information to the key types. 
* 0..n - key with 0 to many values matching. Most cases where we don't have a primary key
* 0/1 - key with have either 0 or 1 matched values. We have a subset of all values in the table. 

Also removed "only" from the percentage tool tip since using both "only 99%" "only 1%" doesn't make sense.