### PR TITLE
fix: Choosing a new start table by clicking on the table header now works again

### DIFF
--- a/src/components/model.jsx
+++ b/src/components/model.jsx
@@ -95,7 +95,7 @@ export default function Model({ app, appLayout, isLocalStorage }) {
       showFieldDetails(table, field, boxId);
     } else if (dataTableHeader) {
       // Re-sort the main data model based on the clicked table
-      const newQueryModel = new logic.QueryModel(tablesAndKeys, table);
+      const newQueryModel = new logic.QueryModel(tablesAndKeys, dataTableHeader);
       setQueryModel(newQueryModel);
     } else if (field) {
       // Open or close a field


### PR DESCRIPTION
Now using the dataTableHeader variable as table name instead since the tablez attribute was not set on the level in the dom (And moving the attribute broke other things....) 