### PR TITLE
chore: apt-get update before awscli install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ jobs:
           name: Sync dist to S3 bucket
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${TARGET_USER}" != "" ]; then
+              sudo apt-get update
               sudo apt-get -y -qq install awscli
               aws configure set preview.cloudfront true
 


### PR DESCRIPTION
the deploy CCI job is failing with
```
#!/bin/bash -eo pipefail
if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${TARGET_USER}" != "" ]; then
  sudo apt-get -y -qq install awscli
  aws configure set preview.cloudfront true

  npm run build
  aws s3 sync dist/ s3://catwalk-qlik-dev/ --delete
  aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
fi

E: Failed to fetch http://deb.debian.org/debian/pool/main/p/pillow/python3-pil_5.4.1-2+deb10u2_amd64.deb  404  Not Found [IP: 146.75.34.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Exited with code exit status 100
CircleCI received exit code 100
```

This PR is an attempt to fix this